### PR TITLE
updated dependency for BSON

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bson>=0.5.2
 inject>=3.3.1
 paho-mqtt>=1.2
 msgpack-python>=0.4.8
+pymongo>=3.6.1


### PR DESCRIPTION
BSON package works with pymongo pip package as stated in https://github.com/RobotWebTools/rosbridge_suite/issues/198