### PR TITLE
several changes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>python-inject-pip</exec_depend>
+  <!-- <exec_depend>python dict-to-protobuf</exec_depend> -->
   <!-- <exec_depend>python-inject-pip</exec_depend> -->
   <!-- <exec_depend>python-msgpack</exec_depend> -->
   <!-- <exec_depend>python-paho-mqtt-pip</exec_depend> -->

--- a/scripts/mqtt_bridge_node.py
+++ b/scripts/mqtt_bridge_node.py
@@ -4,7 +4,6 @@ import rospy
 
 from mqtt_bridge.app import mqtt_bridge_node
 
-
 try:
     mqtt_bridge_node()
 except rospy.ROSInterruptException:

--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -4,13 +4,14 @@ from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 
 import inject
+import dict_to_protobuf
 import paho.mqtt.client as mqtt
 import rospy
 
-from .util import lookup_object, extract_values, populate_instance
+from .util import lookup_object, extract_values, populate_instance, match_wildcards
 
 
-def create_bridge(factory, msg_type, topic_from, topic_to, **kwargs):
+def create_bridge(factory, msg_type, **kwargs):
     u""" bridge generator function
 
     :param (str|class) factory: Bridge class
@@ -30,8 +31,7 @@ def create_bridge(factory, msg_type, topic_from, topic_to, **kwargs):
         raise TypeError(
             "msg_type should be rospy.Message instance or its string"
             "reprensentation")
-    return factory(
-        topic_from=topic_from, topic_to=topic_to, msg_type=msg_type, **kwargs)
+    return factory(msg_type=msg_type, **kwargs)
 
 
 class Bridge(object):
@@ -58,12 +58,19 @@ class RosToMqttBridge(Bridge):
     :param (float|None) frequency: publish frequency
     """
 
-    def __init__(self, topic_from, topic_to, msg_type, frequency=None):
+    def __init__(self, topic_from, topic_to, msg_type, frequency=None, qos=2, retain=False, delete_retained_on_shutdown=False):
         self._topic_from = topic_from
         self._topic_to = self._extract_private_path(topic_to)
         self._last_published = rospy.get_time()
         self._interval = 0 if frequency is None else 1.0 / frequency
+        self._qos = qos
+        self._retain = retain
         rospy.Subscriber(topic_from, msg_type, self._callback_ros)
+        if delete_retained_on_shutdown:
+            rospy.on_shutdown(self._delete_retained_on_shutdown)
+
+    def _delete_retained_on_shutdown(self):
+        self._mqtt_client.publish(topic=self._topic_to, payload="", qos=self._qos, retain=self._retain)
 
     def _callback_ros(self, msg):
         rospy.logdebug("ROS received from {}".format(self._topic_from))
@@ -74,8 +81,28 @@ class RosToMqttBridge(Bridge):
 
     def _publish(self, msg):
         payload = bytearray(self._serialize(extract_values(msg)))
-        self._mqtt_client.publish(topic=self._topic_to, payload=payload)
+        self._mqtt_client.publish(topic=self._topic_to, payload=payload, qos=self._qos, retain=self._retain)
 
+class RosProtoToMqttBridge(RosToMqttBridge):
+    u""" Bridge from ROS topic to MQTT
+
+    :param str topic_from: incoming ROS topic path
+    :param str topic_to: outgoing MQTT topic path
+    :param class msg_type: subclass of ROS Message
+    :param (float|None) frequency: publish frequency
+    """
+
+    def __init__(self, topic_from, topic_to, msg_type, proto_type, frequency=None, qos=2, retain=False, delete_retained_on_shutdown=False):
+        RosToMqttBridge.__init__(self, topic_from, topic_to, msg_type, frequency, qos, retain, delete_retained_on_shutdown)
+        if isinstance(proto_type, basestring):
+            proto_type = lookup_object(proto_type)
+        self._proto_type = proto_type
+
+    def _publish(self, msg):
+        obj = self._proto_type()
+        dict_to_protobuf.parse_dict(extract_values(msg), obj)
+        payload = obj.SerializeToString()
+        self._mqtt_client.publish(topic=self._topic_to, payload=payload, qos=self._qos, retain=self._retain)
 
 class MqttToRosBridge(Bridge):
     u""" Bridge from MQTT to ROS topic
@@ -88,18 +115,19 @@ class MqttToRosBridge(Bridge):
     """
 
     def __init__(self, topic_from, topic_to, msg_type, frequency=None,
-                 queue_size=10):
+                 queue_size=10, wildcards=None, latch=False):
         self._topic_from = self._extract_private_path(topic_from)
         self._topic_to = topic_to
         self._msg_type = msg_type
         self._queue_size = queue_size
+        self._wildcards = wildcards
         self._last_published = rospy.get_time()
         self._interval = None if frequency is None else 1.0 / frequency
 
-        self._mqtt_client.subscribe(topic_from)
-        self._mqtt_client.message_callback_add(topic_from, self._callback_mqtt)
+        self._mqtt_client.subscribe(self._topic_from)
+        self._mqtt_client.message_callback_add(self._topic_from, self._callback_mqtt)
         self._publisher = rospy.Publisher(
-            self._topic_to, self._msg_type, queue_size=self._queue_size)
+            self._topic_to, self._msg_type, queue_size=self._queue_size, latch=latch)
 
     def _callback_mqtt(self, client, userdata, mqtt_msg):
         u""" callback from MQTT
@@ -114,6 +142,15 @@ class MqttToRosBridge(Bridge):
         if self._interval is None or now - self._last_published >= self._interval:
             try:
                 ros_msg = self._create_ros_message(mqtt_msg)
+                if self._wildcards is not None:
+                    wildcard_matchs, hash_wildcards = match_wildcards(self._topic_from, mqtt_msg.topic)
+                    wildcard_matchs.extend(hash_wildcards)
+                    for wildcard, value in zip(self._wildcards, wildcard_matchs):
+                        ros_msg_tmp = ros_msg
+                        wildcard_split = wildcard.split(".")
+                        for field in wildcard_split[:-1]:
+                            ros_msg_tmp = getattr(ros_msg_tmp, field)
+                        setattr(ros_msg_tmp, wildcard_split[-1], value)
                 self._publisher.publish(ros_msg)
                 self._last_published = now
             except Exception as e:
@@ -125,9 +162,19 @@ class MqttToRosBridge(Bridge):
         :param mqtt.Message mqtt_msg: MQTT Message
         :return rospy.Message: ROS Message
         """
-        msg_dict = self._deserialize(mqtt_msg.payload)
-        return populate_instance(msg_dict, self._msg_type())
+        if self._msg_type._type == "std_msgs/String":
+            x = self._msg_type()
+            x.data = mqtt_msg.payload
+            return x
+        else:
+            if len(mqtt_msg.payload) > 0:
+                msg_dict = self._deserialize(mqtt_msg.payload)
+            elif self._msg_type._type == "std_msgs/Empty":
+                msg_dict = {}
+            else:
+                msg_dict = {}
+            return populate_instance(msg_dict, self._msg_type())
 
 
 __all__ = ['register_bridge_factory', 'create_bridge', 'Bridge',
-           'RosToMqttBridge', 'MqttToRosBridge']
+           'RosToMqttBridge', 'RosProtoToMqttBridge', 'MqttToRosBridge']

--- a/src/mqtt_bridge/util.py
+++ b/src/mqtt_bridge/util.py
@@ -4,6 +4,22 @@ from importlib import import_module
 
 from rosbridge_library.internal import message_conversion
 
+def match_wildcards(wild_topic, topic):
+    wild_topic = wild_topic.split("/")
+    topic = topic.split("/")
+    result = []
+    hash_wildcard = []
+    while topic:
+        wild_field = wild_topic[0]
+        field = topic.pop(0)
+        if wild_field == "+":
+            result.append(field)
+            wild_topic.pop(0)
+        elif wild_field == "#":
+            hash_wildcard.append(field)
+        else:
+            wild_topic.pop(0)
+    return result, hash_wildcard
 
 def lookup_object(object_path, package='mqtt_bridge'):
     """ lookup object from a some.module:object_name specification. """


### PR DESCRIPTION
We've been relying on mqtt_bridge for an interface with one of our customers. In this pull request are all the modifications to mqtt_bridge that we made in the process:

1. allow retained messages (with `retain: True`)
2. allow setting the qos (e.g. with `qos: 1`)
3. new bridge type: RosProtoToMqttBridge. This compresses the data from the ros message with protobuf. It is necessary to specify the `proto_type`, in the same format like `msg_type`, e.g. my_proto_msgs.State_pb2:State
4. allow topic wildcards for + and #. E.g. with topic=sensors/+/value, wildcards=[sensorId] you get a sensorId=temperature001 if you receive the topic sensors/temperature001/value
5. allow to send mqtt disconnect on shutdown by setting the parameter mqtt.disconnect_on_shutdown to True
6. handle std_msgs/String and std_msgs/Empty more efficiently
7. allow the mqtt client_id to be set according to the mac address of an interface by setting the parameter mqtt.client.client_id_from_mac to the correct interface

I know that's a lot of changes. Let me know if you don't like any of those and I will create a pull request without them.