### PR TITLE
Enable solve python dependency by using cmake command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,3 +18,6 @@ install(DIRECTORY launch
 install(DIRECTORY config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
 )
+
+
+add_custom_target(install_depends ALL COMMAND "pip" "install" "-r" "${PROJECT_SOURCE_DIR}/requirements.txt")

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>mosquitto</exec_depend>
+  <!--<exec_depend>mosquitto-clients</exec_depend>-->
   <!-- <exec_depend>python-inject-pip</exec_depend> -->
   <!-- <exec_depend>python-msgpack</exec_depend> -->
   <!-- <exec_depend>python-paho-mqtt-pip</exec_depend> -->

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bson>=0.5.2
 inject>=3.3.1
 paho-mqtt>=1.2
 msgpack-python>=0.4.8
+pymongo


### PR DESCRIPTION
In your instructions, we have to install extra modules by ourselves.
So, I solve this problem by using add_custom_target cmake command.