### PR TITLE
mqtt subscribing to private path had a small bug

### DIFF
--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -95,9 +95,9 @@ class MqttToRosBridge(Bridge):
         self._queue_size = queue_size
         self._last_published = rospy.get_time()
         self._interval = None if frequency is None else 1.0 / frequency
-
-        self._mqtt_client.subscribe(topic_from)
-        self._mqtt_client.message_callback_add(topic_from, self._callback_mqtt)
+        # Adding the correct topic to subscribe to
+        self._mqtt_client.subscribe(self._topic_from)
+        self._mqtt_client.message_callback_add(self._topic_from, self._callback_mqtt)
         self._publisher = rospy.Publisher(
             self._topic_to, self._msg_type, queue_size=self._queue_size)
 

--- a/src/mqtt_bridge/mqtt_client.py
+++ b/src/mqtt_bridge/mqtt_client.py
@@ -56,7 +56,6 @@ def default_mqtt_client_factory(params):
 def create_private_path_extractor(mqtt_private_path):
     def extractor(topic_path):
         if topic_path.startswith('~/'):
-            rospy.logdebug('{}/{}'.format(mqtt_private_path, topic_path[2:]))
             return '{}/{}'.format(mqtt_private_path, topic_path[2:])
         return topic_path
     return extractor

--- a/src/mqtt_bridge/mqtt_client.py
+++ b/src/mqtt_bridge/mqtt_client.py
@@ -56,6 +56,7 @@ def default_mqtt_client_factory(params):
 def create_private_path_extractor(mqtt_private_path):
     def extractor(topic_path):
         if topic_path.startswith('~/'):
+            rospy.logdebug('{}/{}'.format(mqtt_private_path, topic_path[2:]))
             return '{}/{}'.format(mqtt_private_path, topic_path[2:])
         return topic_path
     return extractor


### PR DESCRIPTION
The Topic to which the mqtt is subscribing in MqttToRosBridge is wrong with respect to the condition of private path. It should use the member variable _topic_from because that has the private path extracted topic name. 