### PR TITLE
Fix 'install_requires' warning when building with --install

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
   <url>http://www.ros.org/wiki/mqtt_bridge</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python-setuptools</buildtool_depend>
+
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
 setup_args = generate_distutils_setup(
     packages=['mqtt_bridge'],


### PR DESCRIPTION
When building the package with install space enabled (`catkin config --install`) I got the following warning:

```
Warnings   << mqtt_bridge:install /opt/enway/ws/logs/mqtt_bridge/build.install.001.log                                                                                                                    
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
cd /opt/enway/ws/build/mqtt_bridge; catkin build --get-env mqtt_bridge | catkin env -si  /usr/bin/make install; cd -
```

distutils apparently doesn't support 'install_requires', replacing it with setuptools (which is also matching the example in http://docs.ros.org/melodic/api/catkin/html/howto/format2/installing_python.html) fixes that.