### PR TITLE
add unittests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+executors:
+  default:
+    docker:
+      - image: cimg/python:2.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+
+jobs:
+  test:
+    executor:
+      name: default
+    steps:
+      - checkout
+      - run: make setup
+      - run: make test
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: setup
+setup:
+	pip install catkin_pkg
+	pip install -r requirements.txt
+	pip install -e .
+
+.PHONY: test
+test:
+	python -m pytest test
+
+.PHONY: circleci-local
+circleci-local:
+	circleci local execute --job test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mqtt_bridge
 
+[![CircleCI](https://circleci.com/gh/groove-x/mqtt_bridge.svg?style=svg)](https://circleci.com/gh/groove-x/mqtt_bridge)
+
 mqtt_bridge provides a functionality to bridge between ROS and MQTT in bidirectional.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,18 @@
-bson>=0.5.2
-inject>=3.3.1
-paho-mqtt>=1.2
+# thanks to rospypi project, we can install ros packages in pure python
+# See: https://github.com/rospypi/simple
+--extra-index-url https://rospypi.github.io/simple/
+catkin-pkg
+geometry-msgs
+inject>=3.3.1,<4.0
 msgpack-python>=0.4.8
+paho-mqtt>=1.2
+pymongo
+pytest
+pyyaml
+git+https://github.com/RobotWebTools/rosbridge_suite.git#subdirectory=rosbridge_library
+rosgraph-msgs
+roslib
+rosmsg
+rospy<1.15  # 1.15 is for python3
+sensor-msgs
+std-msgs

--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -129,5 +129,4 @@ class MqttToRosBridge(Bridge):
         return populate_instance(msg_dict, self._msg_type())
 
 
-__all__ = ['register_bridge_factory', 'create_bridge', 'Bridge',
-           'RosToMqttBridge', 'MqttToRosBridge']
+__all__ = ['create_bridge', 'Bridge', 'RosToMqttBridge', 'MqttToRosBridge']

--- a/src/mqtt_bridge/mqtt_client.py
+++ b/src/mqtt_bridge/mqtt_client.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-import ssl
-
 import paho.mqtt.client as mqtt
-import rospy
 
 
 def default_mqtt_client_factory(params):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,34 @@
+import threading
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+import pytest
+
+
+class ParameterServerMock(BaseHTTPRequestHandler):
+    """ mock server for unittest
+
+    Parameter Server API: http://wiki.ros.org/ROS/Parameter%20Server%20API
+    Master Slave APIs: http://wiki.ros.org/ROS/Master_Slave_APIs
+    """
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-type", "application/xml")
+        self.end_headers()
+        body = """<?xml version="1.0"?>
+        <methodResponse>
+          <params>
+            <param><value><int>-1</int></value></param>
+            <param><value><string>this is a dummy error response</string></value></param>
+            <param><value><int>0</int></value></param>
+          </params>
+        </methodResponse>"""
+        self.wfile.write(body.encode())
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_mock_parameter_server(request):
+    server_address = ('', 11311)
+    httpd = HTTPServer(server_address, ParameterServerMock)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()

--- a/test/test_mqtt_client.py
+++ b/test/test_mqtt_client.py
@@ -1,0 +1,6 @@
+from mqtt_bridge.mqtt_client import create_private_path_extractor
+
+
+def test_create_private_path_extractor():
+    extract = create_private_path_extractor("mqtt/server1")
+    assert extract("~/some/path") == "mqtt/server1/some/path"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,28 @@
+from mqtt_bridge.bridge import RosToMqttBridge
+from mqtt_bridge.util import extract_values, populate_instance, lookup_object
+from sensor_msgs.msg import Temperature
+from std_msgs.msg import Header
+
+
+def test_lookup_object():
+    obj = lookup_object('mqtt_bridge.bridge:RosToMqttBridge')
+    assert obj == RosToMqttBridge
+
+
+def test_extract_values():
+    msg = Temperature(
+        header=Header(),
+        temperature=25.2,
+        variance=0.0,
+    )
+    expected = {'header': {'stamp': {'secs': 0, 'nsecs': 0}, 'frame_id': '', 'seq': 0}, 'temperature': 25.2, 'variance': 0.0}
+    actual = extract_values(msg)
+    assert expected == actual
+
+
+def test_populate_instance():
+    msg_dict = {'header': {'stamp': {'secs': 0, 'nsecs': 0}, 'frame_id': '', 'seq': 0}, 'temperature': 25.2, 'variance': 0.0}
+    msg = Temperature()
+    populate_instance(msg_dict, msg)
+    assert msg.temperature == 25.2
+    assert msg.variance == 0.0


### PR DESCRIPTION
add unittests for this package.

- use [rospypi](https://github.com/rospypi/simple) to install dependent modules in pure python environment
- run dummy parameter server on unittest, because rosbridge_library calles `rospy.get_param` internally
- configure circleci