### PR TITLE
Use rosdep to install python dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,3 @@ install(DIRECTORY launch
 install(DIRECTORY config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-
-add_custom_target(install_depends ALL COMMAND "pip3" "install" "--user" "-r" "${PROJECT_SOURCE_DIR}/requirements.txt")

--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,10 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <!--<exec_depend>python3-msgpack</exec_depend> -->
-  <!--<exec_depend>python3-paho-mqtt</exec_depend> -->
+  <exec_depend>python3-msgpack</exec_depend>
+  <exec_depend>python3-paho-mqtt</exec_depend>
   <exec_depend>python3-pymongo</exec_depend>
-  <!--<exec_depend>python3-inject</exec_depend> -->
+  <exec_depend>python-inject</exec_depend>
 
   <export>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <exec_depend>python3-msgpack</exec_depend>
   <exec_depend>python3-paho-mqtt</exec_depend>
   <exec_depend>python3-pymongo</exec_depend>
-  <exec_depend>python-inject</exec_depend>
+  <exec_depend>python-inject-pip</exec_depend>
 
   <export>
   </export>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-inject>=4.0
-msgpack-python>=0.4.8
-paho-mqtt>=1.2
-pymongo


### PR DESCRIPTION
In the [RoboStack](https://github.com/RoboStack/ros-noetic/pull/113) project that combines Conda with ROS we were running into problems building mqtt_bridge because of the custom pip install target. This PR removes this and uses standard rosdep to install the dependencies.