### PR TITLE
rosdep for python + setuptools warnings

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,13 @@
 
   <url>http://www.ros.org/wiki/mqtt_bridge</url>
 
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>python3-msgpack</exec_depend>
+  <exec_depend>python3-paho-mqtt</exec_depend>
+  <exec_depend>python3-pymongo</exec_depend>
+  <exec_depend>python-inject-pip</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/mqtt_bridge
+script_dir=$base/lib/mqtt_bridge
 [install]
-install-scripts=$base/lib/mqtt_bridge
+install_scripts=$base/lib/mqtt_bridge


### PR DESCRIPTION
* ADD python dependencies to package.xml (see pull request of @cadmus-to or the latest PR for the `master` branch)
* UPDATE setup.cfg to use underscore name's instead of dash-seperated 'script-dir' and 'install-scripts' to support future versions of setuptools
![setuptools-UserWarning](https://user-images.githubusercontent.com/34453849/188394177-4946503e-1e2e-490d-8dba-8c85387fb295.jpg)
