### PR TITLE
Replaced message filler/reader in utils to work with newer stuff..

### DIFF
--- a/mqtt_bridge/bridge.py
+++ b/mqtt_bridge/bridge.py
@@ -57,6 +57,8 @@ class RosToMqttBridge(Bridge):
             self._last_published = now
 
     def _publish(self, msg):
+        values = extract_values(msg)
+        #self.ros_node.get_logger().info(f"EXTRACT VALUES -- \nmsg:{msg}\nvalues:{values}\n---")
         payload = self._serialize(extract_values(msg))
         self._mqtt_client.publish(topic=self._topic_to, payload=payload)
 
@@ -101,6 +103,8 @@ class MqttToRosBridge(Bridge):
             msg_dict = self._deserialize(mqtt_msg.payload, raw=False)
         else:
             msg_dict = self._deserialize(mqtt_msg.payload)
+            
+        #self.ros_node.get_logger().info(f"--- POPULATE INSTANCE\nmsg_dict:\n{msg_dict}\n\nmsg_type:{self._msg_type()}\n\npopulate:\n{populate_instance(msg_dict, self._msg_type())}")
         return populate_instance(msg_dict, self._msg_type())
 
 

--- a/mqtt_bridge/util.py
+++ b/mqtt_bridge/util.py
@@ -1,7 +1,10 @@
 from importlib import import_module
 from typing import Any, Callable, Dict
 
-from rosbridge_library.internal import message_conversion
+# does not do lists... replaced with rosidl_runtime_py stuff! 
+#from rosbridge_library.internal import message_conversion
+from rosidl_runtime_py.set_message import set_message_fields
+from rosidl_runtime_py.convert import message_to_ordereddict
 
 def lookup_object(object_path: str, package: str='mqtt_bridge') -> Any:
     """ lookup object from a some.module:object_name specification. """
@@ -10,8 +13,14 @@ def lookup_object(object_path: str, package: str='mqtt_bridge') -> Any:
     obj = getattr(module, obj_name)
     return obj
 
+def populate_instance(msg_dict, msg_type):
+    set_message_fields(msg_type, msg_dict)
+    return msg_type
 
-extract_values = message_conversion.extract_values  
-populate_instance = message_conversion.populate_instance 
+def extract_values(msg):
+    return message_to_ordereddict(msg)
+
+#extract_values = message_conversion.extract_values  
+#populate_instance = message_conversion.populate_instance 
 
 __all__ = ['lookup_object', 'extract_values', 'populate_instance']


### PR DESCRIPTION
## What
Replaced `rosbridge_library.message_conversion:extract_values` and `populate_instance()` functions with equivalent `rosidl_runtime_py` functions.

## Why
The old functions could not handle the case when a ROS Message had a list of other ROS messages as a field. The new ones can.
