### PR TITLE
Record the dependency on inject < 5

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>mqtt_bridge</name>
   <version>0.2.1</version>
   <description>The mqtt_bridge package</description>
@@ -21,7 +21,7 @@
   <exec_depend>python3-msgpack</exec_depend>
   <exec_depend>python3-paho-mqtt</exec_depend>
   <exec_depend>python3-pymongo</exec_depend>
-  <exec_depend>python-inject-pip</exec_depend>
+  <exec_depend version_lt="5.0.0">python3-inject-pip</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
## What

Add `version_lt` attribute to inject dependency so that it is explicit that version 4 needs to be installed.

## Why

Inject 5+ is not compatible with Python 3.8 which is the default for Noetic/Focal.

---

This PR itself will not convince rosdep to install the correct version due to https://github.com/ros-infrastructure/rosdep/issues/325 . However, at least it will be documented that version 5 is not compatible.